### PR TITLE
Indicate Safari 13 unprefixed support for sticky

### DIFF
--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -257,14 +257,24 @@
               "opera_android": {
                 "version_added": "43"
               },
-              "safari": {
-                "prefix": "-webkit-",
-                "version_added": "6.1"
-              },
-              "safari_ios": {
-                "prefix": "-webkit-",
-                "version_added": "6.1"
-              },
+              "safari": [
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
+                },
+                {
+                  "version_added": "13"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
+                },
+                {
+                  "version_added": "13"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "6.0"
               },

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -268,11 +268,11 @@
               ],
               "safari_ios": [
                 {
-                  "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "13"
                 },
                 {
-                  "version_added": "13"
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
                 }
               ],
               "samsunginternet_android": {

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -259,11 +259,11 @@
               },
               "safari": [
                 {
-                  "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "13"
                 },
                 {
-                  "version_added": "13"
+                  "prefix": "-webkit-",
+                  "version_added": "6.1"
                 }
               ],
               "safari_ios": [


### PR DESCRIPTION
[Data here](https://wpt.fyi/results/css/css-position?diff&filter=ADC&q=sticky&run_id=311390003&run_id=308980004).
